### PR TITLE
Add Windows packaging instructions and GUI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # Spotcloud
 Spotify and Soundcloud playlist audio downloader
+
+## Building a Windows Executable
+
+1. Install the required dependencies:
+   ```bash
+   pip install spotdl yt-dlp pyinstaller
+   ```
+2. Run PyInstaller to create a standalone EXE:
+   ```bash
+   pyinstaller --onefile --windowed -n Spotcloud main.py
+   ```
+   The resulting `Spotcloud.exe` will be located in the `dist` folder.
+
+To run the unit tests instead of launching the GUI, execute:
+
+```bash
+python main.py test
+```

--- a/main.py
+++ b/main.py
@@ -167,7 +167,11 @@ def get_soundcloud_queries(sc_url: str) -> List[str]:
 # ──────────────────────────────────────────────────────────────────────────────
 # GUI layer – only when Tk present & script executed directly
 # ──────────────────────────────────────────────────────────────────────────────
-if HAS_TK and __name__ == "__main__":
+def run_gui() -> None:
+    """Launch the SpotCloud Tkinter interface."""
+    if not HAS_TK:
+        raise RuntimeError("Tkinter is not available")
+
     # ── Modern look & feel ---------------------------------------------------
     root = tk.Tk()
     root.title(APP)
@@ -399,4 +403,9 @@ class TestHelpers(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    if len(sys.argv) > 1 and sys.argv[1] == "test":
+        unittest.main(argv=[sys.argv[0]] + sys.argv[2:])
+    elif HAS_TK:
+        run_gui()
+    else:
+        print("Tkinter is not available; run with 'python main.py test' to execute unit tests.")


### PR DESCRIPTION
## Summary
- add instructions for building a standalone Windows executable with PyInstaller
- wrap GUI code into a `run_gui` function and conditionally invoke it
- allow running unit tests with `python main.py test`

## Testing
- `python -m unittest main.py`

------
https://chatgpt.com/codex/tasks/task_e_686e84e0702c832da8d8b6e693959453